### PR TITLE
#40 add validation for phone number, email and website

### DIFF
--- a/app/Http/Requests/StorePlaces.php
+++ b/app/Http/Requests/StorePlaces.php
@@ -47,11 +47,11 @@ class StorePlaces extends FormRequest
             'deliveryType' => ['required'],
             'placeType' => ['required'],
             'region_id' => ['required'],
-            'email' => ['nullable', 'email'],
-            'url' => ['nullable', 'url'],
+            'email' => ['nullable', 'email', 'required_without_all:url,phoneNumber'],
+            'url' => ['nullable', 'url', 'required_without_all:email,phoneNumber'],
             'facebook_url' => ['nullable', 'url'],
             'hide_address' => ['boolean'],
-            'phoneNumber' => ['nullable', 'phone:CA'],
+            'phoneNumber' => ['nullable', 'phone:CA', 'required_without_all:url,email'],
             'additionnalPhoneNumber' => ['nullable', 'phone:CA'],
             'deliveryZone' => [
                 function ($attribute, $value, $fail) {
@@ -84,6 +84,10 @@ class StorePlaces extends FormRequest
             'facebook_url.url' => "Veuillez vous assurer d'avoir une adresse valide et complète, incluant les <em>http://</em> ou <em>https://</em>.",
             'phoneNumber.phone' => "Assurez vous d'avoir un format de téléphone valide, inclant le code régional.",
             'additionnalPhoneNumber.phone' => "Assurez vous d'avoir un format de téléphone valide, inclant le code régional.",
+            'url.required_without_all' => "Le champ <em>Adresse web</em> est obligatoire si vous n'avez pas remplis le champs <em>No. de tél.</em> ou le champs <em>Courriel</em>.",
+            'phoneNumber.required_without_all' => "Le champ <em>No. de tél.</em> est obligatoire si vous n'avez pas remplis le champs <em>Adresse web</em> ou le champs <em>Courriel</em>.",
+            'email.required_without_all' => "Le champ <em>Courriel</em> est obligatoire si vous n'avez pas remplis le champs <em>Adresse web</em> ou le champs <em>No. de tél.</em>.",
+            'rcm_id.required' => "Le champ MRC est obligatoire.",
         ];
     }
 }


### PR DESCRIPTION
Fixes #40 , includes translations for the new validation.

Note : there seem to be some issues with the RCM seed. Running `php artisan db:seed` doesn't run the RCM seeder.

Also, the front page crashes when no place is in the database (front page tries to show random 6 places).